### PR TITLE
Vc stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Note: The message commands will accept both text in code blocks and not. If a co
 | `!send [channel_id] [message_content]`          | Sends a message to a channel. The channel is the channel which channel_id points to. Bot requires send message permissions in this channel. | Requires the management role (if set) |
 | `!edit [channel_id] [message_id] [new_content]` | Edits the message that can be found in the channel which channel_id points to. The message **must** be from the bot. | Requires the management role (if set) |
 | `!delete [channel_id] [message_id]`             | Deletes the message. The message **must** be from the bot.   | Requires the management role (if set) |
-| `!stats-force-update`             | Update the stats channels | Requires the management role (if set) |
+| `!stats update`             | Update the stats channels | Requires the management role (if set) |
 
 
 ## Important Notes

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ This bot uses JSON for environment variables.
 | owner   | string | User ID | This will appear in the info box from the `!info` command. Leave as `None` if you don't want this to appear. | No |
 | allowed_server | string | Server ID | If set the bot will only respond to commands in this server. Leave as `None` to make the bot respond regardless of server.| No |
 | management_role | string | Role ID | Setting this means that only users with this role can use the bot. Leave it as `None` if you don't want this. **Not Advised** as this will allow `@everyone` to use it. | No |
+| member_channel | Int | Voice Channel ID | The channel that the bot will record the number of non bot users in the server to. Bot requires manage channel permission on this channel to do this | No |
+| bot_channel | Int | Voice Channel ID | The channel that the bot will record the number of bot users in the server to. Bot requires manage channel permission on this channel to do this | No |
 | bypassed_users | int[] | User ids in an array | By adding a user to this this will bypass all user checks. This is useful for if you have set allowed_server, but want some users to still be able to use it. **Dangerous** permission to grant. | No |
 
 ## Commands
@@ -84,6 +86,8 @@ Note: The message commands will accept both text in code blocks and not. If a co
 | `!send [channel_id] [message_content]`          | Sends a message to a channel. The channel is the channel which channel_id points to. Bot requires send message permissions in this channel. | Requires the management role (if set) |
 | `!edit [channel_id] [message_id] [new_content]` | Edits the message that can be found in the channel which channel_id points to. The message **must** be from the bot. | Requires the management role (if set) |
 | `!delete [channel_id] [message_id]`             | Deletes the message. The message **must** be from the bot.   | Requires the management role (if set) |
+| `!stats-force-update`             | Update the stats channels | Requires the management role (if set) |
+
 
 ## Important Notes
 

--- a/cogs/maincog.py
+++ b/cogs/maincog.py
@@ -40,7 +40,7 @@ class MainCog(commands.Cog):
                     True
                 ],    
                 [
-                    f"`{prefix}stats-force-update`",
+                    f"`{prefix}stats update`",
                     "Update the stats channels",
                     True
                 ]        

--- a/cogs/maincog.py
+++ b/cogs/maincog.py
@@ -38,7 +38,12 @@ class MainCog(commands.Cog):
                     f"`{prefix}delete [channel_id] [message_id]`",
                     "Deletes the message from the bot. **Must** be from the bot",
                     True
-                ],            
+                ],    
+                [
+                    f"`{prefix}stats-force-update`",
+                    "Update the stats channels",
+                    True
+                ]        
 
             ]
         )    

--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -29,7 +29,13 @@ class StatsCog(commands.Cog):
         await asyncio.sleep(60)
         await self.update_stats(member)
     
-    @commands.command(name='stats-force-update')
+    @commands.group()
+    async def stats(self, ctx):
+        if ctx.invoked_subcommand is None:
+            pass
+    
+    
+    @stats.command(name='update')
     async def stats_force_update(self, ctx):
         await self.update_stats(ctx)
         await ctx.send("Stats updated!")

--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -1,0 +1,40 @@
+import discord, asyncio
+from discord.ext import commands
+from src import helpers, checks
+
+member_channel = helpers.fetch_config('member_channel')
+bot_channel = helpers.fetch_config('bot_channel')
+
+class StatsCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot 
+    
+    async def update_stats(self, ctx):
+        member_channel_obj = self.bot.get_channel(int(member_channel))
+        bot_channel_obj = self.bot.get_channel(int(bot_channel))
+        member_count = len([m for m in ctx.guild.members if not m.bot])
+        bot_count = len([m for m in ctx.guild.members if m.bot])
+        if not member_channel_obj.name[12:] == str(member_count):
+            await member_channel_obj.edit(name = f'User Count: {int(member_count)}')
+        if not bot_channel_obj.name[11:] == str(bot_count):
+            await bot_channel_obj.edit(name = f'Bot Count: {int(bot_count)}')
+    
+    @commands.Cog.listener()
+    async def on_member_join(self, member):
+        await asyncio.sleep(60)
+        await self.update_stats(member)
+    
+    @commands.Cog.listener()
+    async def on_member_leave(self, member):
+        await asyncio.sleep(60)
+        await self.update_stats(member)
+    
+    @commands.command(name='stats-force-update')
+    async def stats_force_update(self, ctx):
+        await self.update_stats(ctx)
+        await ctx.send("Stats updated!")
+
+
+
+def setup(bot):
+    bot.add_cog(StatsCog(bot))

--- a/example_config.json
+++ b/example_config.json
@@ -6,5 +6,7 @@
 	"management_role":"None",
 	"bypassed_users": [
 		
-	]
+	],
+	"member_channel":0,
+	"bot_channel":0
 }

--- a/main.py
+++ b/main.py
@@ -62,14 +62,10 @@ async def on_guild_join(guild):
 extensions = [
     'cogs.maincog',
     'cogs.messages',
-    'cogs.admin'
+    'cogs.admin',
+    'cogs.stats'
 ]
 for extension in extensions:
     bot.load_extension(extension)
-"""
-bot.load_extension('cogs.maincog')
-bot.load_extension('cogs.messages')
-bot.load_extension('cogs.admin')
-"""
+    
 bot.run(token)
-

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from src import helpers, checks
 
 # Start up the discord logging module.
 logger = logging.getLogger('discord')
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.INFO)
 handler = logging.FileHandler(filename='discord.log', encoding='utf-8', mode='w')
 handler.setFormatter(logging.Formatter('%(asctime)s:%(levelname)s:%(name)s: %(message)s'))
 logger.addHandler(handler)


### PR DESCRIPTION
Add capability to be able to constantly have a two voice channels displaying user count and bot count.
To do this:
 - A cog {`cog.stats`} was added and setup
 - Listeners added to on join and on leave events
 - Command group stats added with subcommand update