### PR TITLE
Remove extra requirements that were added from pip freeze

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,1 @@
-aiohttp==3.6.2
-async-timeout==3.0.1
-attrs==20.1.0
-chardet==3.0.4
 discord.py==1.4.1
-idna==2.10
-multidict==4.7.6
-websockets==8.1
-yarl==1.5.1


### PR DESCRIPTION
When i first created the `requirements.txt` file i just used `pip freeze`, and it caught all the packages of discord.py as well. 
I've reduced it to just what i use.